### PR TITLE
Updating XDS protocol docs location

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Currently Supports
 
 *Note: Some infrequent configurations might not be mapped. Feel free to PR* 
 
-Checkout [Envoy XDS PROTOCOL Overview](https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.md) for more detail
+Checkout [Envoy XDS PROTOCOL Overview](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol) for more detail
 
 Also Checkout Sample Project 
    * [Envoy xDS Example From File](https://github.com/tak2siva/Envoy-xDS-Example-From-File)


### PR DESCRIPTION
The repository this references has now deleted it's standalone readme file and instead points to docs on envoyproxy.io.